### PR TITLE
Add config for contact sensor name overide

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -28,6 +28,12 @@
                 "default": false,
                 "description": "The switch includes a combined contact sensor."
             },
+            "contactName": {
+                "title": "Contact Name",
+                "type": "string",
+                "default": "",
+                "description": "A name for the contact sensor. Defaults to the name of the switch"
+            },
             "reverse": {
                 "title": "Reverse",
                 "type": "boolean",

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ function DummySwitch(log, config) {
   this.stateful = config.stateful;
   this.reverse = config.reverse;
   this.contact = config['contact'] || false;
+  this.contactName = config.contactName || this.name;
   this.time = config.time ? config.time : 1000;
   this.switch = config['switch'] || false;
   this.timerObject = null;
@@ -29,7 +30,7 @@ function DummySwitch(log, config) {
       .addCharacteristic(Characteristic.Brightness);
   }
 
-  this._contact = new Service.ContactSensor(this.name);
+  this._contact = new Service.ContactSensor(this.contactName);
 
   this.cacheDirectory = HomebridgeAPI.user.persistPath();
   this.storage = require('node-persist');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-dummy-contact",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Dummy switches for Homebridge: https://github.com/nfarina/homebridge",
   "license": "ISC",
   "keywords": [


### PR DESCRIPTION
This PR adds a new config option "contactName", which can be used to give the created contact sensor a name different from that of the switch. This property is optional and the name defaults to that of the switch.